### PR TITLE
feat: Add functionality to add new columns to existing board

### DIFF
--- a/app/api/addColumn/route.ts
+++ b/app/api/addColumn/route.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from "@prisma/client";
+
+import { NextResponse } from "next/server";
+import { update } from "@/utils/actions";
+const prisma = new PrismaClient();
+
+export const POST = async (request: Request) => {
+  try {
+    const { name, boardId } = await request.json();
+
+    const newColumn = await prisma.column.create({
+      data: {
+        name,
+        board: {
+          connect: { id: boardId },
+        },
+      },
+    });
+
+    update(["/kanban"]);
+
+    return NextResponse.json({ data: { ...newColumn } });
+  } catch (error) {
+    console.error("Error adding column:", error);
+    return NextResponse.json(
+      { error: "Failed to add column" },
+      { status: 500 }
+    );
+  }
+};

--- a/app/kanban/board/layout.tsx
+++ b/app/kanban/board/layout.tsx
@@ -4,7 +4,7 @@ export default function Layout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="w-full flex flex-col md:flex-row h-fit overflow-scroll">
+    <div className="w-full flex flex-col md:flex-row h-auto overflow-scroll">
       <div className="w-full flex-grow p-6 md:overflow-y-auto md:p-0">
         {children}
       </div>

--- a/components/kanban/kanban-card.tsx
+++ b/components/kanban/kanban-card.tsx
@@ -18,7 +18,7 @@ const KanbanCard = ({ task, setState, totalSubtasks }: KanbanCardProps) => {
   }
 
   return (
-    <div className="flex flex-col gap-4 h-[auto] min-h-[140px] mb-4">
+    <div className="flex flex-col gap-4 mb-4">
       <button
         onClick={() =>
           handleViewTask(task.title, task.id, task.description ?? "")

--- a/constants/initial-data.ts
+++ b/constants/initial-data.ts
@@ -14,6 +14,7 @@ export const INITIAL_STATE: StateT = {
   openModul: false,
   taskName: "",
   taskId: "",
+  columns: [],
   columnName: "",
   columnId: "",
   columnOrder: [],

--- a/types/data-types.ts
+++ b/types/data-types.ts
@@ -12,6 +12,7 @@ export interface StateT {
   openModul: boolean;
   taskName: string;
   taskId: string;
+  columns: ColumnState[];
   columnName: string;
   columnId: string;
   columnOrder: any[];


### PR DESCRIPTION
This commit adds the ability to add new columns to an existing board in the KanbanGrid component. It introduces a new input field where users can enter the name of the new column and a button to trigger the addition. The handleAddColumn function sends a POST request to the "/api/addColumn" endpoint with the new column name and the board ID. Upon successful response, the new column is added to the state and the page is refreshed to reflect the changes.